### PR TITLE
Local host with ip and api version support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ var conceptNet = ConceptNet();
 ```
 
 In case that you are running an own copy of the ConceptNet server, the constructor takes the hostname of the
-server as an optional argument. The default option evaluates to "conceptnet5.media.mit.edu".
+server as an optional argument. The default option evaluates to "conceptnet5.media.mit.edu:80".
 
 ```
-ConceptNet('hostname', 'port', 'conceptnet version number');
+ConceptNet('<hostname>', '<port>', '<conceptnet version number>');
 ```
 
-Example code:
+Example:
 ```
 var conceptNet = ConceptNet('10.0.0.1', '10053', '5.3');
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 node-ConceptNet
 ===============
 
-node.js interface to the ConceptNet semantic network API. For further information, consult the website of the project: 
+node.js interface to the ConceptNet semantic network API. For further information, consult the website of the project:
 [http://conceptnet5.media.mit.edu/](http://conceptnet5.media.mit.edu/).
 
 
@@ -22,9 +22,9 @@ To require the module in a project, we can use the expression:
 var ConceptNet = require('concept-net');
 ```
 
-# Getting Started 
+# Getting Started
 
-The module exports a single constructor which can be used to open an API connection. Simply call it an store the 
+The module exports a single constructor which can be used to open an API connection. Simply call it an store the
 expression result in a variable:
 
 ```
@@ -34,18 +34,32 @@ var conceptNet = ConceptNet();
 In case that you are running an own copy of the ConceptNet server, the constructor takes the hostname of the
 server as an optional argument. The default option evaluates to "conceptnet5.media.mit.edu".
 
+```
+ConceptNet('hostname', 'port', 'conceptnet version number');
+```
+
+Example code:
+```
+var conceptNet = ConceptNet('10.0.0.1', '10053', '5.3');
+```
+Note you can modify only the version by just passing null to the first two arguments:
+
+```
+var conceptNet = ConceptNet(null, null, '5.3');
+```
+
 We can then use the following three methods to query the ConceptNet API:
 
-## Methods 
+## Methods
 
 ### `.lookup(uri, [params], callback)`
 
 This method expects a valid ConceptNet URI as its first argument. See [the documentation](https://github.com/commonsense/conceptnet5/wiki/URI-hierarchy).
 Params is an (optional) object that specifies the arguments of the GET request. It can have the keys *limit*, *offset* and
 *filter*. The callback function has two parameters: The *err* parameter will return error objects in case that something goes
-wrong during the function invocation. If the query is successfull, *err* is `undefined` and the *result* parameter holds the result set from the query. 
+wrong during the function invocation. If the query is successfull, *err* is `undefined` and the *result* parameter holds the result set from the query.
 
-Example code: 
+Example code:
 ```
 conceptNet.lookup("/c/en/toast",{
 	limit: 10,
@@ -59,9 +73,9 @@ conceptNet.lookup("/c/en/toast",{
 
 The search method takes a parameter object and hands the retrieved results to the callback function.
 The official ConceptNet API documentation provides a full overview of the possible search parameters:
-[ConceptNet API documentation](https://github.com/commonsense/conceptnet5/wiki/API). 
+[ConceptNet API documentation](https://github.com/commonsense/conceptnet5/wiki/API).
 
-Example code: 
+Example code:
 ```
 conceptNet.search({
 text: "donut"}, function(err, result){
@@ -74,7 +88,7 @@ text: "donut"}, function(err, result){
 The association method takes as its first input either a valid ConceptNet URI or a `/list/<language>/<term list>`
 path.
 
-Example code: 
+Example code:
 ```
 conceptNet.association("/c/en/hotdog",{
 	limit: 10,

--- a/src/store.js
+++ b/src/store.js
@@ -4,90 +4,90 @@ var querystring = require('querystring');
 // constructor function
 function ConceptNet(host, port, version){
 
-	// if not invoked as a constructor call
-	if (!(this instanceof ConceptNet)){
-		return new ConceptNet(host, port, version);
-	}
+  // if not invoked as a constructor call
+  if (!(this instanceof ConceptNet)){
+    return new ConceptNet(host, port, version);
+  }
 
-	this.host = host || 'conceptnet5.media.mit.edu';
-	this.version = version || '5.2'
-	this.port = parseInt(port || 80)
+  this.host = host || 'conceptnet5.media.mit.edu';
+  this.version = version || '5.2'
+  this.port = parseInt(port || 80)
 }
 
 ConceptNet.prototype.buildOptions = function(path){
-	var options = {};
-	options.hostname = this.host;
-	options.port = this.port;
-	options.path = path;
-	return options;
+  var options = {};
+  options.hostname = this.host;
+  options.port = this.port;
+  options.path = path;
+  return options;
 }
 
 ConceptNet.prototype.lookup = function(URI, params, callback){
 
-	var limit = params.limit || 50;
-	var offset = params.offset || 0;
+  var limit = params.limit || 50;
+  var offset = params.offset || 0;
 
-	var path = "/data/" + this.version + String(URI) + "?limit=" + limit + "&offset=" + offset;
-	if (params.filter === "core") path += "&filter=core";
+  var path = "/data/" + this.version + String(URI) + "?limit=" + limit + "&offset=" + offset;
+  if (params.filter === "core") path += "&filter=core";
 
-	this.makeHtppRequest(this.buildOptions(path), callback);
+  this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 ConceptNet.prototype.search = function(params, callback){
-	var path = "/data/" + this.version + "/search?";
+  var path = "/data/" + this.version + "/search?";
 
-	var str = querystring.stringify(params);
-	str = querystring.unescape(str);
-	path += str;
+  var str = querystring.stringify(params);
+  str = querystring.unescape(str);
+  path += str;
 
-	this.makeHtppRequest(this.buildOptions(path), callback);
+  this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 function isConceptNetURI(uri){
-	var  myRegEx = /\/(?:[acdelrs]|and|or)\/[a-zA-Z]{2}\/\w+/;
-	return (myRegEx.test(uri) ? true : false);
+  var  myRegEx = /\/(?:[acdelrs]|and|or)\/[a-zA-Z]{2}\/\w+/;
+  return (myRegEx.test(uri) ? true : false);
 }
 
 function isValidTermPath(path){
-	var myRegEx = /\/list\/[a-zA-Z]{2}\/\w+(?:@[-+]?[0-9]*\.?[0-9]+)?(,\w+(?:@[-+]?[0-9]*\.?[0-9]+)?)*/;
-	return (myRegEx.test(path) ? true : false);
+  var myRegEx = /\/list\/[a-zA-Z]{2}\/\w+(?:@[-+]?[0-9]*\.?[0-9]+)?(,\w+(?:@[-+]?[0-9]*\.?[0-9]+)?)*/;
+  return (myRegEx.test(path) ? true : false);
 }
 
 ConceptNet.prototype.association = function(input, params, callback){
 
-		if(!isConceptNetURI(input) && !isValidTermPath(input)){
-			var err = new Error("The input argument must be either a valid ConceptNet URI or a path of the form " +
-					"/list/<language>/<term list>");
-			return callback(err);
-		}
+    if(!isConceptNetURI(input) && !isValidTermPath(input)){
+      var err = new Error("The input argument must be either a valid ConceptNet URI or a path of the form " +
+          "/list/<language>/<term list>");
+      return callback(err);
+    }
 
-		var path = "/data/" + this.version + "/assoc" + String(input) + "?limit" + limit;
-		var limit = params.limit || 10;
+    var path = "/data/" + this.version + "/assoc" + String(input) + "?limit" + limit;
+    var limit = params.limit || 10;
 
-		if (params.filter){
-			if (isConceptNetURI(params.filter)) path += "&filter" + params.filter;
-			else{
-				var err2 = new Error("The GET argument filter must be a valid ConceptNet URI.");
-				return callback(err2);
-			}
-		}
+    if (params.filter){
+      if (isConceptNetURI(params.filter)) path += "&filter" + params.filter;
+      else{
+        var err2 = new Error("The GET argument filter must be a valid ConceptNet URI.");
+        return callback(err2);
+      }
+    }
 
-		this.makeHtppRequest(this.buildOptions(path), callback);
+    this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 ConceptNet.prototype.makeHtppRequest = function(options, callback){
-	var retrieve = function(response){
-	var str = '';
-	response.on('data', function (chunk) {
-			str += chunk;
-		});
+  var retrieve = function(response){
+    var str = '';
+    response.on('data', function (chunk) {
+      str += chunk;
+    });
 
-		response.on('end', function () {
-			callback(undefined, JSON.parse(str));
-		});
-	};
-
-	http.request(options, retrieve).end();
+    response.on('end', function () {
+        callback(undefined, JSON.parse(str));
+    });
+  };
+  
+  http.request(options, retrieve).end();
 };
 
 // export node module

--- a/src/store.js
+++ b/src/store.js
@@ -2,15 +2,24 @@ var http = require('http');
 var querystring = require('querystring');
 
 // constructor function
-function ConceptNet(host){
+function ConceptNet(host, port, version){
 
 	// if not invoked as a constructor call
 	if (!(this instanceof ConceptNet)){
-		return new ConceptNet();
+		return new ConceptNet(host, port, version);
 	}
 
-	this.host = host ||'conceptnet5.media.mit.edu';
+	this.host = host || 'conceptnet5.media.mit.edu';
+	this.version = version || '5.2'
+	this.port = parseInt(port || 80)
+}
 
+ConceptNet.prototype.buildOptions = function(path){
+	var options = {};
+	options.hostname = this.host;
+	options.port = this.port;
+	options.path = path;
+	return options;
 }
 
 ConceptNet.prototype.lookup = function(URI, params, callback){
@@ -18,28 +27,20 @@ ConceptNet.prototype.lookup = function(URI, params, callback){
 	var limit = params.limit || 50;
 	var offset = params.offset || 0;
 
-	var path = "/data/5.2" + String(URI) + "?limit=" + limit + "&offset=" + offset;
+	var path = "/data/" + this.version + String(URI) + "?limit=" + limit + "&offset=" + offset;
 	if (params.filter === "core") path += "&filter=core";
 
-	var options = {};
-	options.host = this.host;
-	options.path = path;
-
-	this.makeHtppRequest(options, callback);
+	this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 ConceptNet.prototype.search = function(params, callback){
-	 var path = "/data/5.2/search?";
+	var path = "/data/" + this.version + "/search?";
 
-	 var str = querystring.stringify(params);
-	 str = querystring.unescape(str);
-	 path += str;
+	var str = querystring.stringify(params);
+	str = querystring.unescape(str);
+	path += str;
 
-	 var options = {};
-	 options.host = this.host;
-	 options.path = path;
-
-	 this.makeHtppRequest(options, callback);
+	this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 function isConceptNetURI(uri){
@@ -60,37 +61,33 @@ ConceptNet.prototype.association = function(input, params, callback){
 			return callback(err);
 		}
 
-	 	 var path = "/data/5.2/assoc" + String(input) + "?limit" + limit;
-		 var limit = params.limit || 10;
+		var path = "/data/" + this.version + "/assoc" + String(input) + "?limit" + limit;
+		var limit = params.limit || 10;
 
-		 if (params.filter){
-			 if (isConceptNetURI(params.filter)) path += "&filter" + params.filter;
-			 else{
-				 var err2 = new Error("The GET argument filter must be a valid ConceptNet URI.");
-				 return callback(err2);
-			 }
-		 }
+		if (params.filter){
+			if (isConceptNetURI(params.filter)) path += "&filter" + params.filter;
+			else{
+				var err2 = new Error("The GET argument filter must be a valid ConceptNet URI.");
+				return callback(err2);
+			}
+		}
 
-		 var options = {};
-		 options.host = this.host;
-		 options.path = path;
-
-		 this.makeHtppRequest(options, callback);
+		this.makeHtppRequest(this.buildOptions(path), callback);
 };
 
 ConceptNet.prototype.makeHtppRequest = function(options, callback){
-	 var retrieve = function(response){
-	 var str = '';
-	 response.on('data', function (chunk) {
-	    str += chunk;
-	  });
+	var retrieve = function(response){
+	var str = '';
+	response.on('data', function (chunk) {
+			str += chunk;
+		});
 
-	  response.on('end', function () {
-	    callback(undefined, JSON.parse(str));
-	  });
-	 };
+		response.on('end', function () {
+			callback(undefined, JSON.parse(str));
+		});
+	};
 
-	 http.request(options, retrieve).end();
+	http.request(options, retrieve).end();
 };
 
 // export node module

--- a/test/test.js
+++ b/test/test.js
@@ -1,27 +1,71 @@
 var assert = require("assert");
-var conceptNet = require('../src/store.js');	
+var conceptNet = require('../src/store.js');
 
 describe('conceptNet', function () {
 	  describe('config', function () {
-		  
-		  var cnet;
 		  it('creates an instance of conceptNet', function (done) {
-			  cnet = new conceptNet();
+			  var cnet = new conceptNet();
 			  assert(cnet instanceof conceptNet);
 			  done();
-		      });  
-		  
+		      });
+			describe('defaults', function(){
+				it('has default hostname', function (done) {
+					var cnet = new conceptNet();
+					assert(cnet.host == 'conceptnet5.media.mit.edu');
+					done();
+				});
+
+				it('has default port', function (done) {
+					var cnet = new conceptNet();
+					assert(cnet.port == 80);
+					done();
+				});
+
+				it('has default version', function (done) {
+					var cnet = new conceptNet();
+					assert(cnet.version = '5.2');
+					done();
+				});
+			});
+
+			describe('override', function(){
+				it('has set hostname', function (done) {
+					var cnet = new conceptNet('10.0.0.1','1234','5.3');
+					assert(cnet.host == '10.0.0.1');
+					done();
+				});
+
+				it('has set port', function (done) {
+					var cnet = new conceptNet('10.0.0.1','1234','5.3');
+					assert(cnet.port == 1234);
+					done();
+				});
+
+				it('has set version', function (done) {
+					var cnet = new conceptNet('10.0.0.1','1234','5.3');
+					assert(cnet.version == '5.3');
+					done();
+				});
+
+				it('only overrides the version', function(done){
+					var cnet = new conceptNet(null, null,'5.3');
+					assert(cnet.host == 'conceptnet5.media.mit.edu')
+					assert(cnet.version == '5.3');
+					done();
+				})
+			});
+
 		  it('looks up a single concept URI', function (done) {
-			  this.timeout(500);
-			  cnet = new conceptNet();
+			  this.timeout(1000);
+			  var cnet = new conceptNet();
 			  cnet.lookup("/c/en/toast",{
 				    limit: 1,
 				    offset: 0,
 				    filter: "core"}, function(err, result){
 				      assert(result.numFound > 0)
 				      done()
-				    }) 
+				    }
+				)
 		  });
-		     
 	  });
 });


### PR DESCRIPTION
I am using concept net locally via their docker instance and it creates an ip:port based local host. I modded the constructor (that was dropping the host argument before) to carry host, port, version info. My local docker instance is also up to 5.3 now so I needed that api version info.

Added tests to cover defaults and specified values. Pulled the options building out to a shared function. 

My editor stripped trailing white space so the commit looks worse than it is in places. Updated Readme with examples.