### PR TITLE
Handle Arabic characters

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -29,7 +29,9 @@ ConceptNet.prototype.lookup = function(URI, params, callback) {
     var limit = params.limit || 50;
     var offset = params.offset || 0;
 
-    var path = "/data/" + this.version + String(URI) + "?limit=" + limit + "&offset=" + offset;
+    var path = "/data/" + this.version + String(encodeURIComponent(URI)) +
+        "?limit=" + limit + "&offset=" + offset;
+
     if ( params.filter === "core" ) {
         path += "&filter=core";
     }

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,16 @@ describe('conceptNet', function tests() {
 				);
 			});
 
+			it('handles concepts in other languages', function otherLangTest(done) {
+				this.timeout(1000);
+				var cnet = new conceptNet();
+				cnet.lookup("c/ar/سلام/",{
+					filter: "core"}, function(err, result){
+						assert(result.edges.length === 7);
+						done();
+					}
+				);
+			});
 		});
 
 		it('is possible to use search method to retrieve results', function test(done) {


### PR DESCRIPTION
Updated lookup to encode URI so that Arabic characters in the path don't cause it to get a bad request response, then crash on JSON.parse.