### PR TITLE
update for ConceptNet 5.4; add URIstd for standardization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,27 @@ conceptNet.lookup("/c/en/toast",{
 	})
 ```
 
+### `.URIstd(language, text, callback)`
+
+This method finds out what the [ConceptNet URI](https://github.com/commonsense/conceptnet5/wiki/API#uri-standardization) is for a given text, applying steps such as reducing English words to their root form.
+
+Example code:
+```
+conceptNet.URIstd('en', 'ground beef', function(err, result){
+	// insert code here
+})
+```
+
 ### `.search(params, callback)`
 
 The search method takes a parameter object and hands the retrieved results to the callback function.
 The official ConceptNet API documentation provides a full overview of the possible search parameters:
-[ConceptNet API documentation](https://github.com/commonsense/conceptnet5/wiki/API).
+[ConceptNet API documentation](https://github.com/commonsense/conceptnet5/wiki/API#search).
 
 Example code:
 ```
 conceptNet.search({
-text: "donut"}, function(err, result){
+start: "/c/en/donut"}, function(err, result){
 	 // insert code here
 	})
 ```

--- a/src/store.js
+++ b/src/store.js
@@ -12,7 +12,7 @@ function ConceptNet( host, port, version ) {
     }
 
     this.host = host || 'conceptnet5.media.mit.edu';
-    this.version = version || '5.2';
+    this.version = version || '5.4';
     this.port = parseInt(port || 80);
 }
 
@@ -35,6 +35,15 @@ ConceptNet.prototype.lookup = function( URI, params, callback ) {
     if ( params.filter === "core" ) {
         path += "&filter=core";
     }
+
+    this.makeHtppRequest(this.buildOptions(path), callback);
+};
+
+ConceptNet.prototype.URIstd = function( language, text, callback ) {
+
+    text = text.replace(/\s+/g, '_');
+
+    var path = "/data/" + this.version + "/uri?language=" + language + "&text=" + String( encodeURIComponent(text) );
 
     this.makeHtppRequest(this.buildOptions(path), callback);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ describe( 'conceptNet', function tests() {
 
 			it( 'has default version', function test( done ) {
 				var cnet = new conceptNet();
-				assert( cnet.version === '5.2' );
+				assert( cnet.version === '5.4' );
 				done();
 			});
 		});
@@ -106,24 +106,46 @@ describe( 'conceptNet', function tests() {
 			it( 'handles concepts in other languages', function otherLangTest( done ) {
 				this.timeout(2000);
 				var cnet = new conceptNet();
-				cnet.lookup('c/ar/سلام/',{
+				cnet.lookup('/c/ja/車',{
 					filter: 'core'}, function( err, result ) {
-						assert( result.edges.length === 7 );
+						assert( result.edges.length === 50 );
 						done();
 					}
 				);
 			});
 		});
 
-		it( 'is possible to use search method to retrieve results', function test( done ) {
+		it( 'is possible to use search method to find ConceptNet edges for multiple requirements', function test( done ) {
 			this.timeout(2000);
 			var cnet = new conceptNet();
-			cnet.search({text: 'donut'}, function( err, result ) {
+			cnet.search({start: '/c/en/donut'}, function( err, result ) {
 				assert( result.numFound > 0 );
 				done();
 			});
 		});
 
+		describe( '.URIstd()', function tests() {
+
+			it( 'looks up the ConceptNet URI for text (english)', function test( done ) {
+				this.timeout(2000);
+				var cnet = new conceptNet();
+				cnet.URIstd('en', 'ground beef', function( err, result ) {
+						assert( result.uri == '/c/en/grind_beef' );
+						done();
+					}
+				);
+			});
+
+			it( 'looks up the ConceptNet URI for text (foreign language)', function test( done ) {
+				this.timeout(2000);
+				var cnet = new conceptNet();
+				cnet.URIstd('ja', '車', function( err, result ) {
+						assert( result.uri == '/c/ja/車' );
+						done();
+					}
+				);
+			});
+		});
 
 		describe( '.association()', function tests() {
 
@@ -142,10 +164,10 @@ describe( 'conceptNet', function tests() {
 				this.timeout(3000);
 				var cnet = new conceptNet();
 				cnet.association('/c/en/cat', {
-					limit: 4,
+					limit: 1,
 					filter: '/c/en/dog'},
 					function( err, result ) {
-						assert( result.similar.length === 4 );
+						assert( result.similar.length === 1 );
 						done();
 					});
 			});


### PR DESCRIPTION
Hi, I notice it's been a while since the last update, and there's considerable changes in ConceptNet 5.4. Can you review the PR and publish it so we can use the latest ConceptNet?

changes:
- Update to be compatible with ConceptNet 5.4
- Add [URI standardization](https://github.com/commonsense/conceptnet5/wiki/API#uri-standardization)
- [Search](https://github.com/commonsense/conceptnet5/wiki/API#search) in ConceptNet 5.4 is for finding edges. Update the tests and docs
- update docs and tests
