### PR TITLE
Handle errors of HTTP requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -257,7 +257,9 @@ ConceptNet.prototype.association = function() {
 * @param {Function} callback - callback function
 */
 ConceptNet.prototype.makeHtppRequest = function( options, callback ) {
-	http.request( options, retrieve ).end();
+	var request;
+
+	request = http.request( options, retrieve );
 	function retrieve ( response ) {
 		var str = '';
 		response.on( 'data', function onData( chunk ) {
@@ -266,7 +268,14 @@ ConceptNet.prototype.makeHtppRequest = function( options, callback ) {
 		response.on( 'end', function onEnd() {
 			callback( undefined, JSON.parse( str ) );
 		});
+		response.on( 'error', function onError( error ) {
+			callback( error );
+		});
 	}
+	request.on( 'error', function onError( error ) {
+		callback( error );
+	});
+	request.end();
 }; // end METHOD makeHtppRequest()
 
 


### PR DESCRIPTION
On some cases, the request fails. And, as a failure, the Node app crash.

```
events.js:163
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND conceptnet5.media.mit.edu conceptnet5.media.mit.edu:80
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:73:26)
```